### PR TITLE
Add requirements.txt for python detectors

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,13 @@ Don't forget to click on the **play** button on the bottom left corner of the Ig
 
 <br>
 
-### 2.Launch the Object Detection node
+### 2. Launch the Object Detection node
 <br>
+
+Use the pip install command as shown below to install the required packages.
+```bash
+pip install -r src/ros-perception-pipeline/object_detection/requirements.txt
+```
 
 Use the command given below to run the ObjectDetection node. Remember to change the path of the object_detection.yaml
 file according to your present working directory

--- a/object_detection/requirements.txt
+++ b/object_detection/requirements.txt
@@ -1,0 +1,9 @@
+keras-retinanet==1.0.0
+matplotlib==3.7.1
+numpy==1.25.0
+opencv-python==4.7.0.72
+pandas==2.0.3
+pillow==9.5.0
+tensorflow==2.12.0
+tensorflow-hub==0.13.0
+ultralytics==8.0.124


### PR DESCRIPTION
This is for issue #20 

Added `requirements.txt` to include dependencies for `YOLOv5.py`, `YOLOv8.py`, `RetinaNet.py`, and `EffecientDet.py`.
*(Dependencies are sorted by alphabetical order.)*

Added a `pip install` step to the `launch the object detection node` section in `Readme`.

Fixed small spacing typo in `Readme`.

